### PR TITLE
Fixes UnityEngine.dll path on linux (fixes #2)

### DIFF
--- a/Assets/Core.AssemblyPacker/Editor/Packer.cs
+++ b/Assets/Core.AssemblyPacker/Editor/Packer.cs
@@ -269,7 +269,7 @@ namespace CoreEditor.AssemblyPacker
 		
 		public static string GetFrameWorksFolder()
 		{
-			if (Application.platform == RuntimePlatform.WindowsEditor)
+			if (Application.platform == RuntimePlatform.WindowsEditor || Application.platform == RuntimePlatform.LinuxEditor)
 			{
 				return (Path.GetDirectoryName(EditorApplication.applicationPath) + "/Data/");
 			}


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1264761/21584343/aee59898-d072-11e6-8a85-a53751537d48.png)
